### PR TITLE
V0.0.6

### DIFF
--- a/Verticality/Lib/CollisionUtils.cs
+++ b/Verticality/Lib/CollisionUtils.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+using Vintagestory.API.Common;
 using Vintagestory.API.MathTools;
+using Vintagestory.Common;
 
 namespace Verticality.Lib
 {
@@ -78,6 +80,32 @@ namespace Verticality.Lib
             Array.ConstrainedCopy(arr1, 0, outArr, 0, arr1.Length);
             Array.ConstrainedCopy(arr2, 0, outArr, arr1.Length, arr2.Length);
             return outArr;
+        }
+
+        // Returns new position, moved to closest horizontal edge
+        public static Vec3d MoveToEdge(Cuboidf box, Vec3d pos)
+        {
+            Vec3d fromMiddle = pos.SubCopy(box.Center);
+            if (Math.Abs(fromMiddle.X) > Math.Abs(fromMiddle.Z))
+            {
+                if (fromMiddle.X > 0)
+                {
+                    return new(box.MaxX, pos.Y, pos.Z);
+                } else
+                {
+                    return new(box.MinX, pos.Y, pos.Z);
+                }
+            } else
+            {
+                if (fromMiddle.Z > 0)
+                {
+                    return new(pos.X, pos.Y, box.MaxZ);
+                }
+                else
+                {
+                    return new(pos.X, pos.Y, box.MaxZ);
+                }
+            }
         }
     }
 }

--- a/Verticality/Lib/ConfigManager.cs
+++ b/Verticality/Lib/ConfigManager.cs
@@ -88,13 +88,14 @@ namespace Verticality.Lib
                         api.Logger.Event("[{0}] generating new config", new object[] { NetChannel });
                         _modConfig = new VerticalityModConfig();
                         api.StoreModConfig(_modConfig, ConfigFilename);
-                    }
+                    } else api.Logger.Event("[{0}] config loaded", new object[] { NetChannel });
                     BroadcastConfig();
                     break;
             }
         }
         public void RequestConfig()
         {
+            api.Logger.Event("[{0}] requesting config from server", new object[] { NetChannel });
             capi.Network.GetChannel(NetChannel).SendPacket<NetMessage_Request>(new());
             api.Event.RegisterCallback((float d) => { requestedConfig = false; }, 5000);
         }
@@ -111,6 +112,7 @@ namespace Verticality.Lib
         }
         public void BroadcastConfig()
         {
+            api.Logger.Event("[{0}] broadcasting config to all players", new object[] { NetChannel });
             sapi.Network.GetChannel(NetChannel).BroadcastPacket(modConfig);
         }
 

--- a/Verticality/Moves/Climb/ClimbPatch.cs
+++ b/Verticality/Moves/Climb/ClimbPatch.cs
@@ -1,0 +1,19 @@
+﻿using HarmonyLib;
+using System.Collections.Generic;
+using Vintagestory.API.Common.Entities;
+using Vintagestory.GameContent;
+
+namespace Verticality.Moves.Climb
+{
+    [HarmonyPatch]
+    public static class ClimbPatch
+    {
+        [HarmonyPrefix]
+        [HarmonyPatch(typeof(EntityBehaviorPlayerPhysics), nameof(EntityBehaviorPlayerPhysics.SetModules))]
+        public static void SetGrabPModule(EntityBehaviorPlayerPhysics __instance)
+        {
+            List<PModule> physicsModules = Traverse.Create(__instance).Field("physicsModules").GetValue<List<PModule>>();
+            physicsModules.Add(new PModuleGrab());
+        }
+    }
+}

--- a/Verticality/Moves/Climb/EntityBehaviorClimb.cs
+++ b/Verticality/Moves/Climb/EntityBehaviorClimb.cs
@@ -69,9 +69,12 @@ namespace Verticality.Moves.Climb
                     if (grab.CanStillGrab())
                     {
                         //player.Properties.CanClimbAnywhere = true;
-                        Grab.debugParticles.MinPos = grab.grabPos.FullPosition;
-                        Grab.debugParticles.Color = ColorUtil.WhiteArgb;
-                        player.World.SpawnParticles(Grab.debugParticles);
+                        if (VerticalityModSystem.ClientConfig.showDebugParticles)
+                        {
+                            Grab.debugParticles.MinPos = grab.grabPos.FullPosition;
+                            Grab.debugParticles.Color = ColorUtil.WhiteArgb;
+                            player.World.SpawnParticles(Grab.debugParticles);
+                        }
                     }
                     else
                     {

--- a/Verticality/Moves/Climb/EntityBehaviorClimb.cs
+++ b/Verticality/Moves/Climb/EntityBehaviorClimb.cs
@@ -2,6 +2,7 @@
 using Vintagestory.API.Client;
 using Vintagestory.API.Common;
 using Vintagestory.API.Common.Entities;
+using Vintagestory.API.MathTools;
 
 namespace Verticality.Moves.Climb
 {
@@ -31,7 +32,7 @@ namespace Verticality.Moves.Climb
             }
         }
 
-        private Grab grab;
+        public Grab grab;
 
         public bool ClimbKeyDown
         {
@@ -66,18 +67,21 @@ namespace Verticality.Moves.Climb
                 {
                     if (grab.CanStillGrab())
                     {
-                        player.Properties.CanClimbAnywhere = true;
+                        //player.Properties.CanClimbAnywhere = true;
+                        Grab.debugParticles.MinPos = grab.grabPos.FullPosition;
+                        Grab.debugParticles.Color = ColorUtil.WhiteArgb;
+                        player.World.SpawnParticles(Grab.debugParticles);
                     }
                     else
                     {
                         grab = Grab.TryGrab(player);
-                        if (grab == null) player.Properties.CanClimbAnywhere = false;
+                        //if (grab == null) player.Properties.CanClimbAnywhere = false;
                     }
                 }
             }
             else if (grab != null)
             {
-                player.Properties.CanClimbAnywhere = false;
+                //player.Properties.CanClimbAnywhere = false;
                 grab = null;
             }
         }

--- a/Verticality/Moves/Climb/EntityBehaviorClimb.cs
+++ b/Verticality/Moves/Climb/EntityBehaviorClimb.cs
@@ -1,4 +1,5 @@
-﻿using Verticality.Lib;
+﻿using System;
+using Verticality.Lib;
 using Vintagestory.API.Client;
 using Vintagestory.API.Common;
 using Vintagestory.API.Common.Entities;
@@ -61,7 +62,7 @@ namespace Verticality.Moves.Climb
             {
                 if (grab == null)
                 {
-                    grab = Grab.TryGrab(player);
+                    grab = Grab.TryGrab(player, null, null, (float?)(grabDistance * Math.Max(1, player.Pos.Motion.Length() * 3)));
                 }
                 else
                 {

--- a/Verticality/Moves/Climb/Grab.cs
+++ b/Verticality/Moves/Climb/Grab.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Security.Cryptography;
 using Vintagestory.API.Client;
 using Vintagestory.API.Common;
 using Vintagestory.API.MathTools;
@@ -174,13 +175,17 @@ namespace Verticality.Moves.Climb
             float[] offsets = new float[]
             {
                 0,
-                0.1f, -0.1f,
-                0.25f, -0.25f,
-                0.5f, -0.5f
+                0.12f, -0.12f,
+                0.25f, -0.25f
             };
             foreach (float offset in offsets)
             {
                 Vec3d outPos = DoGrabRaycast(player, offset * GameMath.PIHALF);
+                if (outPos != null) return outPos;
+            }
+            foreach (float offset in offsets)
+            {
+                Vec3d outPos = DoGrabRaycast(player, offset * GameMath.PIHALF, (float)player.LocalEyePos.Y);
                 if (outPos != null) return outPos;
             }
             return null;
@@ -188,9 +193,14 @@ namespace Verticality.Moves.Climb
 
         public static Vec3d DoGrabRaycast(EntityPlayer player, float yawOffset = 0)
         {
+            return DoGrabRaycast(player, yawOffset, minHeight);
+        }
+
+        public static Vec3d DoGrabRaycast(EntityPlayer player, float yawOffset, float heightOffset)
+        {
             ICoreClientAPI capi = player.Api as ICoreClientAPI;
 
-            Ray ray = Ray.FromAngles(player.Pos.XYZ.AddCopy(0, minHeight, 0), 0, (player.Pos.Yaw - GameMath.PI) + yawOffset, grabDistance);
+            Ray ray = Ray.FromAngles(player.Pos.XYZ.AddCopy(0, heightOffset, 0), 0, (player.Pos.Yaw - GameMath.PI) + yawOffset, grabDistance);
             AABBIntersectionTest aabb = player.World.InteresectionTester;
             aabb.LoadRayAndPos(ray);
             BlockSelection bs = aabb.GetSelectedBlock((float)ray.Length, null, true);

--- a/Verticality/Moves/Climb/Grab.cs
+++ b/Verticality/Moves/Climb/Grab.cs
@@ -104,6 +104,7 @@ namespace Verticality.Moves.Climb
         // Find closest collision, if any, within a region of blocks in front of player
         // if collision found, crawl up surface until a gap is found or max height reached
         // return location of gap, if any
+        [Obsolete]
         public static Vec3d GetGrabLocation(EntityPlayer entity)
         {
             float yaw = entity.BodyYaw - GameMath.PIHALF;
@@ -188,21 +189,24 @@ namespace Verticality.Moves.Climb
 
         public static BlockSelection GetGrabLocationByRaycast(EntityPlayer player)
         {
-            float[] offsets = new float[]
+            float[] heightOffsets = new float[] { 
+                minHeight, 
+                (float)player.LocalEyePos.Y * 0.8f
+            };
+            float[] yawOffsets = new float[]
             {
                 0,
                 0.12f, -0.12f,
                 0.25f, -0.25f
             };
-            foreach (float offset in offsets)
+
+            foreach (float heightOffset in heightOffsets)
             {
-                BlockSelection outPos = DoGrabRaycast(player, offset * GameMath.PIHALF);
-                if (outPos != null) return outPos;
-            }
-            foreach (float offset in offsets)
-            {
-                BlockSelection outPos = DoGrabRaycast(player, offset * GameMath.PIHALF, (float)player.LocalEyePos.Y);
-                if (outPos != null) return outPos;
+                foreach (float yawOffset in yawOffsets)
+                {
+                    BlockSelection outPos = DoGrabRaycast(player, yawOffset * GameMath.PIHALF, heightOffset);
+                    if (outPos != null) return outPos;
+                }
             }
             return null;
         }

--- a/Verticality/Moves/Climb/Grab.cs
+++ b/Verticality/Moves/Climb/Grab.cs
@@ -63,10 +63,11 @@ namespace Verticality.Moves.Climb
             double relHeightFeet = grabPos.FullPosition.Y - player.Pos.Y;
             double relHeightEyes = relHeightFeet - player.LocalEyePos.Y;
 
-            if (relHeightFeet >= 0 && relHeightEyes < maxHeight)
-                return player.Pos.HorDistanceTo(grabPos.FullPosition) <= grabDistance;
+            if (relHeightFeet < 0 || relHeightEyes > maxHeight) return false;
 
-            return false;
+            if (grabPos.Block != player.World.BlockAccessor.GetBlock(grabPos.Position)) return false;
+
+            return true;
         }
 
         public static SimpleParticleProperties debugParticles = new()
@@ -218,6 +219,7 @@ namespace Verticality.Moves.Climb
                 while (bs != null && ray.Length > 0)
                 {
                     BlockSelection outSel = bs.Clone();
+                    outSel.Block ??= aabb.bsTester.blockAccessor.GetBlock(outSel.Position); // for some reason, the BlockSelection Clone() doesn't clone the Block field
                     outPos = bs.FullPosition.Clone();
                     ray = Ray.FromPositions(
                         bs.FullPosition.Clone(),
@@ -226,7 +228,10 @@ namespace Verticality.Moves.Climb
                     aabb.LoadRayAndPos(ray);
                     bs = aabb.GetSelectedBlock((float)ray.Length, null, true);
 
-                    if (bs == null) return outSel;
+                    if (bs == null)
+                    {
+                        return outSel;
+                    }
 
                     ray = Ray.FromPositions(
                         outPos.SubCopy(0, 1/128f, 0),

--- a/Verticality/Moves/Climb/Grab.cs
+++ b/Verticality/Moves/Climb/Grab.cs
@@ -65,18 +65,24 @@ namespace Verticality.Moves.Climb
 
             if (relHeightFeet < 0 || relHeightEyes > maxHeight) return false;
 
+            if (!GapCheck(grabPos.FullPosition, player.World.InteresectionTester)) return false;
+
+            return true;
+        }
+
+        public static bool GapCheck(Vec3d pos, AABBIntersectionTest aabb)
+        {
             Ray ray = Ray.FromPositions(
-                grabPos.FullPosition.AddCopy(0, 1 / 64f, 0),
-                grabPos.FullPosition.Clone().SubCopy(0, 1 / 128f, 0)
+                pos.AddCopy(0, 1 / 64f, 0),
+                pos.SubCopy(0, 1 / 128f, 0)
                 );
-            AABBIntersectionTest aabb = player.World.InteresectionTester;
             aabb.LoadRayAndPos(ray);
             BlockSelection bs = aabb.GetSelectedBlock((float)ray.Length, null, true);
             if (bs == null) return false;
 
             ray = Ray.FromPositions(
-                grabPos.FullPosition.Clone(),
-                grabPos.FullPosition.AddCopy(0, 1 / 64f, 0)
+                pos.Clone(),
+                pos.AddCopy(0, 1 / 64f, 0)
                 );
             aabb.LoadRayAndPos(ray);
             bs = aabb.GetSelectedBlock((float)ray.Length, null, true);
@@ -224,7 +230,6 @@ namespace Verticality.Moves.Climb
             AABBIntersectionTest aabb = player.World.InteresectionTester;
             aabb.LoadRayAndPos(ray);
             BlockSelection bs = aabb.GetSelectedBlock((float)ray.Length, null, true);
-            Vec3d outPos = null;
             if (bs != null)
             {
                 bs.HitPosition.Sub(bs.Face.Normald * 1 / 128f);
@@ -235,25 +240,12 @@ namespace Verticality.Moves.Climb
                     );
                 aabb.LoadRayAndPos(ray);
                 bs = aabb.GetSelectedBlock((float)ray.Length, null, true);
-                while (bs != null && ray.Length > 0)
+                while (bs != null && ray.Length > 1/128f)
                 {
-                    BlockSelection outSel = bs.Clone();
-                    outSel.Block ??= aabb.bsTester.blockAccessor.GetBlock(outSel.Position); // for some reason, the BlockSelection Clone() doesn't clone the Block field
-                    outPos = bs.FullPosition.Clone();
-                    ray = Ray.FromPositions(
-                        bs.FullPosition.Clone(),
-                        bs.FullPosition.AddCopy(0, 1 / 64f, 0)
-                        );
-                    aabb.LoadRayAndPos(ray);
-                    bs = aabb.GetSelectedBlock((float)ray.Length, null, true);
-
-                    if (bs == null)
-                    {
-                        return outSel;
-                    }
+                    if (GapCheck(bs.FullPosition, aabb)) return bs;
 
                     ray = Ray.FromPositions(
-                        outPos.SubCopy(0, 1/128f, 0),
+                        bs.FullPosition.SubCopy(0, 1/128f, 0),
                         bottom
                         );
                     aabb.LoadRayAndPos(ray);

--- a/Verticality/Moves/Climb/Grab.cs
+++ b/Verticality/Moves/Climb/Grab.cs
@@ -65,6 +65,8 @@ namespace Verticality.Moves.Climb
 
             if (relHeightFeet < 0 || relHeightEyes > maxHeight) return false;
 
+            if (player.Pos.HorDistanceTo(grabPos.FullPosition) > grabDistance) return false;
+
             if (!GapCheck(grabPos.FullPosition, player.World.InteresectionTester)) return false;
 
             return true;

--- a/Verticality/Moves/Climb/Grab.cs
+++ b/Verticality/Moves/Climb/Grab.cs
@@ -65,7 +65,22 @@ namespace Verticality.Moves.Climb
 
             if (relHeightFeet < 0 || relHeightEyes > maxHeight) return false;
 
-            if (grabPos.Block != player.World.BlockAccessor.GetBlock(grabPos.Position)) return false;
+            Ray ray = Ray.FromPositions(
+                grabPos.FullPosition.AddCopy(0, 1 / 64f, 0),
+                grabPos.FullPosition.Clone().SubCopy(0, 1 / 128f, 0)
+                );
+            AABBIntersectionTest aabb = player.World.InteresectionTester;
+            aabb.LoadRayAndPos(ray);
+            BlockSelection bs = aabb.GetSelectedBlock((float)ray.Length, null, true);
+            if (bs == null) return false;
+
+            ray = Ray.FromPositions(
+                grabPos.FullPosition.Clone(),
+                grabPos.FullPosition.AddCopy(0, 1 / 64f, 0)
+                );
+            aabb.LoadRayAndPos(ray);
+            bs = aabb.GetSelectedBlock((float)ray.Length, null, true);
+            if (bs != null) return false;
 
             return true;
         }

--- a/Verticality/Moves/Climb/PModuleGrab.cs
+++ b/Verticality/Moves/Climb/PModuleGrab.cs
@@ -1,0 +1,93 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Verticality.Lib;
+using Vintagestory.API.Client;
+using Vintagestory.API.Common;
+using Vintagestory.API.Common.Entities;
+using Vintagestory.API.Datastructures;
+using Vintagestory.API.MathTools;
+using Vintagestory.GameContent;
+
+namespace Verticality.Moves.Climb
+{
+    public class PModuleGrab : PModule
+    {
+        float maxHeight => VerticalityModSystem.Config.modConfig.climbMaxHeight;
+        float minHeight => VerticalityModSystem.Config.modConfig.climbMinHeight;
+        float grabDistance => VerticalityModSystem.Config.modConfig.climbGrabDistance;
+        EntityBehaviorClimb climbEB;
+        Grab grab;
+
+        public override bool Applicable(Entity entity, EntityPos pos, EntityControls controls)
+        {
+            if (climbEB != null)
+            {
+                grab = climbEB.grab;
+                return (grab != null) && grab.CanStillGrab();
+            }
+            return false;
+        }
+
+        public override void DoApply(float dt, Entity entity, EntityPos pos, EntityControls controls)
+        {
+            Vec3d walkVectorRelativeToGrabFace = controls.WalkVector.RotatedCopy(grab.grabPos.Face.HorizontalAngleIndex * -GameMath.PIHALF);
+            Vec3d posBefore = grab.grabPos.FullPosition;
+            /*
+            double slide = 0;
+            switch(grab.grabPos.Face.HorizontalAngleIndex)
+            {
+                case 0:
+                case 2:
+                    slide = (pos.Z - grab.grabPos.FullPosition.Z)/2;
+                    break;
+                case 1:
+                case 3:
+                    slide = (pos.X - grab.grabPos.FullPosition.X)/2;
+                    break;
+            }
+            if (!entity.OnGround)
+            {
+                if (grab.TrySlide(slide))
+                {
+                    //pos.Add(grab.grabPos.FullPosition.SubCopy(posBefore).ToVec3f());
+                }
+            }*/
+
+            controls.IsClimbing = true;
+
+            double relHeightEyes = grab.grabPos.FullPosition.Y - (pos.Y + entity.LocalEyePos.Y);
+            double diffV = maxHeight - relHeightEyes;
+
+            Vec3d diffVec = grab.grabPos.FullPosition.SubCopy(pos.XYZ);
+            diffVec.Y = 0;
+            double diffH = diffVec.Length();
+            if (diffH > grabDistance || diffV < 0)
+            {
+                Grab prospectiveNewGrab = Grab.TryGrab((EntityPlayer)entity);
+                if (prospectiveNewGrab != null)
+                {
+                    climbEB.grab = prospectiveNewGrab;
+                    grab = prospectiveNewGrab;
+                }
+                else
+                {
+                    if (diffH > grabDistance) pos.Motion.Add(diffVec.Normalize().Scale(diffH - grabDistance).ToVec3f());
+                    if (diffV < 0) pos.Y -= diffV;
+                }
+            }
+            pos.Motion.Y = -walkVectorRelativeToGrabFace.X * 1.5f;
+        }
+
+        public override void Initialize(JsonObject config, Entity entity)
+        {
+            climbEB = entity.GetBehavior<EntityBehaviorClimb>();
+            if (climbEB == null)
+            {
+                // throw exception?
+            }
+        }
+    }
+}

--- a/Verticality/VerticalityModConfig.cs
+++ b/Verticality/VerticalityModConfig.cs
@@ -8,6 +8,7 @@ namespace Verticality
         public float climbMaxHeight = 0.7f;
         public float climbMinHeight = 0.5f;
         public float climbGrabDistance = 0.5f;
+        public float climbSpeed = 1.5f;
         public float chargedJumpChargeTime = 0.5f;
         public float chargedJumpAddForce = 1.9f;
     }

--- a/Verticality/VerticalityModConfig.cs
+++ b/Verticality/VerticalityModConfig.cs
@@ -12,4 +12,9 @@ namespace Verticality
         public float chargedJumpChargeTime = 0.5f;
         public float chargedJumpAddForce = 1.9f;
     }
+
+    public class VerticalityClientModConfig
+    {
+        public bool showDebugParticles = false;
+    }
 }

--- a/Verticality/VerticalityModSystem.cs
+++ b/Verticality/VerticalityModSystem.cs
@@ -1,4 +1,5 @@
-﻿using Verticality.Lib;
+﻿using HarmonyLib;
+using Verticality.Lib;
 using Verticality.Moves.ChargedJump;
 using Verticality.Moves.Climb;
 using Vintagestory.API.Client;
@@ -8,9 +9,25 @@ namespace Verticality
 {
     public class VerticalityModSystem : ModSystem
     {
+        public const string patchName = "com.profcupcake.verticality";
+
+        Harmony harmony;
         public static ConfigManager Config
         {
             get; private set;
+        }
+        public override void StartPre(ICoreAPI api)
+        {
+            base.StartPre(api);
+
+            harmony = new(patchName);
+            harmony.PatchAll();
+        }
+        public override void Dispose()
+        {
+            base.Dispose();
+
+            harmony.UnpatchAll(patchName);
         }
         public override void Start(ICoreAPI api)
         {

--- a/Verticality/VerticalityModSystem.cs
+++ b/Verticality/VerticalityModSystem.cs
@@ -10,12 +10,19 @@ namespace Verticality
     public class VerticalityModSystem : ModSystem
     {
         public const string patchName = "com.profcupcake.verticality";
+        public const string clientConfigFilename = "verticality-client.json";
 
         Harmony harmony;
         public static ConfigManager Config
         {
             get; private set;
         }
+
+        public static VerticalityClientModConfig ClientConfig
+        {
+            get; private set;
+        }
+
         public override void StartPre(ICoreAPI api)
         {
             base.StartPre(api);
@@ -42,6 +49,15 @@ namespace Verticality
         public override void StartClientSide(ICoreClientAPI capi)
         {
             base.StartClientSide(capi);
+
+            capi.Logger.Event("[verticality] trying to load client config");
+            ClientConfig = capi.LoadModConfig<VerticalityClientModConfig>(clientConfigFilename);
+            if (ClientConfig == null)
+            {
+                capi.Logger.Event("[verticality] generating new client config");
+                ClientConfig = new VerticalityClientModConfig();
+                capi.StoreModConfig(ClientConfig, clientConfigFilename);
+            } else capi.Logger.Event("[verticality] client config loaded");
 
             capi.Input.RegisterHotKey("climb", "Climb", GlKeys.LControl, HotkeyType.MovementControls);
         }

--- a/Verticality/VerticalityModSystem.cs
+++ b/Verticality/VerticalityModSystem.cs
@@ -59,7 +59,7 @@ namespace Verticality
                 capi.StoreModConfig(ClientConfig, clientConfigFilename);
             } else capi.Logger.Event("[verticality] client config loaded");
 
-            capi.Input.RegisterHotKey("climb", "Climb", GlKeys.LControl, HotkeyType.MovementControls);
+            capi.Input.RegisterHotKey("climb", "Climb", GlKeys.R, HotkeyType.MovementControls);
         }
     }
 }

--- a/Verticality/changes.txt
+++ b/Verticality/changes.txt
@@ -1,1 +1,3 @@
-- fixed config issues (i hope)
+- grab now drops if the grabbed block changes
+- implemented fancy new raycast-based ledge detection
+- tightened grab arc: it now roughly checks a 45° arc in front of player (i.e. 22.5° each way from centre)

--- a/Verticality/changes.txt
+++ b/Verticality/changes.txt
@@ -1,4 +1,5 @@
 - implemented fancy new raycast-based ledge detection
 - tightened grab arc: it now roughly checks a 45° arc in front of player (i.e. 22.5° each way from centre)
 - grab now drops if the grab location changes (e.g. block removed or rotated)
-- new custom climbing physics! player will no longer drop from distance, instead being pulled back to grab point
+- new custom climbing physics! player will no longer drop from distance, instead being pulled back to grab point#
+- changed default climb key to R, since the new physics make sprinting and climbing together more difficult

--- a/Verticality/changes.txt
+++ b/Verticality/changes.txt
@@ -1,3 +1,4 @@
 - implemented fancy new raycast-based ledge detection
 - tightened grab arc: it now roughly checks a 45° arc in front of player (i.e. 22.5° each way from centre)
 - grab now drops if the grab location changes (e.g. block removed or rotated)
+- new custom climbing physics! player will no longer drop from distance, instead being pulled back to grab point

--- a/Verticality/changes.txt
+++ b/Verticality/changes.txt
@@ -1,3 +1,3 @@
-- grab now drops if the grabbed block changes
 - implemented fancy new raycast-based ledge detection
 - tightened grab arc: it now roughly checks a 45° arc in front of player (i.e. 22.5° each way from centre)
+- grab now drops if the grab location changes (e.g. block removed or rotated)

--- a/resources/modinfo.json
+++ b/resources/modinfo.json
@@ -6,7 +6,7 @@
         "Professor Cupcake"
     ],
     "description": "Climbing! Also jumping!",
-  "version": "0.0.5",
+  "version": "0.0.6",
     "dependencies": {
         "game": "1.20.0-rc.8"
     }


### PR DESCRIPTION
- implemented fancy new raycast-based ledge detection
- tightened grab arc: it now roughly checks a 45° arc in front of player (i.e. 22.5° each way from centre)
- grab now drops if the grab location changes (e.g. block removed or rotated)
- new custom climbing physics! player will no longer drop from distance, instead being pulled back to grab point
- changed default climb key to R, since the new physics make sprinting and climbing together less viable
- introduced new config option to set vertical climb speed
- introduced client-side config, which currently only has a setting to toggle little particles on your grab point