### PR TITLE
V0.3.0

### DIFF
--- a/Verticality/Moves/Climb/EntityBehaviorClimb.cs
+++ b/Verticality/Moves/Climb/EntityBehaviorClimb.cs
@@ -33,6 +33,24 @@ namespace Verticality.Moves.Climb
             }
         }
 
+        public static float climbJumpHForce
+        {
+            get
+            {
+                return VerticalityModSystem.Config.modConfig.climbJumpHForce;
+            }
+        }
+        public static float climbJumpVForce
+        {
+            get
+            {
+                return VerticalityModSystem.Config.modConfig.climbJumpVForce;
+            }
+        }
+        public int climbJumpCooldown = 1000;
+
+        public long climbJumpTime;
+
         public Grab grab;
 
         public bool ClimbKeyDown
@@ -62,7 +80,8 @@ namespace Verticality.Moves.Climb
             {
                 if (grab == null)
                 {
-                    grab = Grab.TryGrab(player, null, null, (float?)(grabDistance * 1.5));
+                    if (((ICoreClientAPI)entity.Api).ElapsedMilliseconds > climbJumpTime)
+                        grab = Grab.TryGrab(player, null, null, (float?)(grabDistance * 1.5));
                 }
                 else
                 {
@@ -75,6 +94,16 @@ namespace Verticality.Moves.Climb
                             Grab.debugParticles.Color = ColorUtil.WhiteArgb;
                             player.World.SpawnParticles(Grab.debugParticles);
                         }
+
+                        if (((ICoreClientAPI)entity.Api).Input.IsHotKeyPressed("jump"))
+                        {
+                            entity.Pos.Motion
+                                .Add(grab.grabPos.Face.Normald * climbJumpHForce / 60f)
+                                .Add(0, climbJumpVForce / 60f, 0);
+
+                            grab = null;
+                            climbJumpTime = ((ICoreClientAPI)entity.Api).ElapsedMilliseconds + climbJumpCooldown;
+                        }
                     }
                     else
                     {
@@ -83,10 +112,14 @@ namespace Verticality.Moves.Climb
                     }
                 }
             }
-            else if (grab != null)
+            else
             {
-                //player.Properties.CanClimbAnywhere = false;
-                grab = null;
+                climbJumpTime = 0;
+                if (grab != null)
+                {
+                    //player.Properties.CanClimbAnywhere = false;
+                    grab = null;
+                }
             }
         }
     }

--- a/Verticality/Moves/Climb/Grab.cs
+++ b/Verticality/Moves/Climb/Grab.cs
@@ -75,18 +75,18 @@ namespace Verticality.Moves.Climb
 
             //if (player.Pos.HorDistanceTo(grabPos.FullPosition) > grabDistance) return false;
 
-            if (!GapCheck(grabPos.FullPosition, player.World.InteresectionTester)) return false;
+            if (!GapCheck(grabPos.FullPosition, grabPos.Face, player.World.InteresectionTester)) return false;
 
             return true;
         }
 
-        public static bool GapCheck(Vec3d pos, AABBIntersectionTest aabb)
+        public static bool GapCheck(Vec3d pos, BlockFacing face, AABBIntersectionTest aabb)
         {
             BlockSelection _ = null;
-            return GapCheck(pos, aabb, ref _);
+            return GapCheck(pos, face, aabb, ref _);
         }
 
-        public static bool GapCheck(Vec3d pos, AABBIntersectionTest aabb, ref BlockSelection outBS)
+        public static bool GapCheck(Vec3d pos, BlockFacing face, AABBIntersectionTest aabb, ref BlockSelection outBS)
         {
             Ray ray = Ray.FromPositions(
                 pos.AddCopy(0, 1 / 64f, 0),
@@ -102,6 +102,14 @@ namespace Verticality.Moves.Climb
             ray = Ray.FromPositions(
                 pos.Clone(),
                 pos.AddCopy(0, 1 / 64f, 0)
+                );
+            aabb.LoadRayAndPos(ray);
+            bs = aabb.GetSelectedBlock((float)ray.Length, null, true);
+            if (bs != null) return false;
+
+            ray = Ray.FromPositions(
+                pos.AddCopy(0, 1 / 64f, 0),
+                pos.AddCopy(0, 1 / 64f, 0).Add(face.Normalf * 1 / 64f)
                 );
             aabb.LoadRayAndPos(ray);
             bs = aabb.GetSelectedBlock((float)ray.Length, null, true);
@@ -146,7 +154,7 @@ namespace Verticality.Moves.Climb
             hitBS = aabb.GetSelectedBlock((float)ray.Length, null, true);
             if (hitBS == null) return false;
 
-            if (!GapCheck(hitBS.FullPosition, aabb)) return false;
+            if (!GapCheck(hitBS.FullPosition, hitBS.Face, aabb)) return false;
 
             hitBS.Face = bs.Face;
             bs = hitBS;
@@ -214,7 +222,7 @@ namespace Verticality.Moves.Climb
                 bs = aabb.GetSelectedBlock((float)ray.Length, null, true);
                 while (bs != null && ray.Length > 1/128f)
                 {
-                    if (GapCheck(bs.FullPosition, aabb))
+                    if (GapCheck(bs.FullPosition, face, aabb))
                     {
                         bs.Face = face;
                         if (OverhangCheck(ref bs, player, maxHeight, grabDistance, aabb))
@@ -237,7 +245,7 @@ namespace Verticality.Moves.Climb
         {
             Vec3d newPos = grabPos.FullPosition.AddCopy(grabPos.Face.GetHorizontalRotated(90).Normald.Clone().Scale(slide));
             BlockSelection bs = null;
-            if (GapCheck(newPos, player.World.InteresectionTester, ref bs))
+            if (GapCheck(newPos, grabPos.Face, player.World.InteresectionTester, ref bs))
             {
                 bs.Face = grabPos.Face;
                 grabPos = bs;

--- a/Verticality/Moves/Crawl/EntityBehaviorCrawl.cs
+++ b/Verticality/Moves/Crawl/EntityBehaviorCrawl.cs
@@ -17,7 +17,7 @@ namespace Verticality.Moves.Crawl
 
         bool DidKeyPress;
         private bool sneakPressed;
-        
+
         public bool IsCrawling
         {
             get
@@ -64,26 +64,46 @@ namespace Verticality.Moves.Crawl
 
             if (IsLocalPlayer())
             {
-                if (CrawlInputPressed())
+                if (VerticalityModSystem.ClientConfig.holdCrawl)
                 {
-                    if (!DidKeyPress)
+                    if (CrawlInputPressed())
+                    {
+                        if (!IsCrawling)
+                        {
+                            TryCrawl();
+                        };
+                    }
+                    else
                     {
                         if (IsCrawling)
                         {
-                            //capi.ShowChatMessage("trying to stand");
                             TryStand();
                         }
-                        else
-                        {
-                            //capi.ShowChatMessage("trying to crawl");
-                            TryCrawl();
-                        }
-                        DidKeyPress = true;
                     }
                 }
                 else
                 {
-                    DidKeyPress = false;
+                    if (CrawlInputPressed())
+                    {
+                        if (!DidKeyPress)
+                        {
+                            if (IsCrawling)
+                            {
+                                //capi.ShowChatMessage("trying to stand");
+                                TryStand();
+                            }
+                            else
+                            {
+                                //capi.ShowChatMessage("trying to crawl");
+                                TryCrawl();
+                            }
+                            DidKeyPress = true;
+                        }
+                    }
+                    else
+                    {
+                        DidKeyPress = false;
+                    }
                 }
             }
 
@@ -153,14 +173,14 @@ namespace Verticality.Moves.Crawl
             if (VerticalityModSystem.ClientConfig.combinationCrawlKeys)
                 if (capi.Input.IsHotKeyPressed("climb") && capi.Input.IsHotKeyPressed("sneak"))
                     return true;
-            
+
             if (VerticalityModSystem.ClientConfig.dedicatedCrawlKey)
                 if (capi.Input.IsHotKeyPressed("crawl"))
                     return true;
 
             if (VerticalityModSystem.ClientConfig.standOnJump)
                 if (IsCrawling)
-                    if (capi.Input.IsHotKeyPressed("jump"))
+                    if (capi.Input.IsHotKeyPressed("jump") && !VerticalityModSystem.ClientConfig.holdCrawl)
                         return true;
 
             if (VerticalityModSystem.ClientConfig.doubleTapSneakToCrawl)
@@ -175,17 +195,24 @@ namespace Verticality.Moves.Crawl
                             if (capi.ElapsedMilliseconds < doubleTapTime)
                             {
                                 return true;
-                            } else
+                            }
+                            else
                             {
                                 doubleTapTime = capi.ElapsedMilliseconds + VerticalityModSystem.ClientConfig.doubleTapSpeed;
                             }
                         }
-                    } else
+                    }
+                    else
                     {
                         sneakPressed = false;
                     }
                 }
-            
+                else if (VerticalityModSystem.ClientConfig.holdCrawl)
+                {
+                    if (capi.Input.IsHotKeyPressed("sneak"))
+                        return true;
+                }
+
             return false;
         }
 

--- a/Verticality/Moves/Crawl/EntityBehaviorCrawl.cs
+++ b/Verticality/Moves/Crawl/EntityBehaviorCrawl.cs
@@ -16,6 +16,8 @@ namespace Verticality.Moves.Crawl
         EntityProperties baseProperties;
 
         bool DidKeyPress;
+        private bool sneakPressed;
+        
         public bool IsCrawling
         {
             get
@@ -37,7 +39,7 @@ namespace Verticality.Moves.Crawl
         }
 
         private bool IsClientCrawling;
-
+        private long doubleTapTime;
 
         public EntityBehaviorCrawl(Entity entity) : base(entity) { }
 
@@ -151,9 +153,39 @@ namespace Verticality.Moves.Crawl
             if (VerticalityModSystem.ClientConfig.combinationCrawlKeys)
                 if (capi.Input.IsHotKeyPressed("climb") && capi.Input.IsHotKeyPressed("sneak"))
                     return true;
+            
             if (VerticalityModSystem.ClientConfig.dedicatedCrawlKey)
                 if (capi.Input.IsHotKeyPressed("crawl"))
                     return true;
+
+            if (VerticalityModSystem.ClientConfig.standOnJump)
+                if (IsCrawling)
+                    if (capi.Input.IsHotKeyPressed("jump"))
+                        return true;
+
+            if (VerticalityModSystem.ClientConfig.doubleTapSneakToCrawl)
+                if (!IsCrawling)
+                {
+                    if (capi.Input.IsHotKeyPressed("sneak"))
+                    {
+                        if (!sneakPressed)
+                        {
+                            sneakPressed = true;
+
+                            if (capi.ElapsedMilliseconds < doubleTapTime)
+                            {
+                                return true;
+                            } else
+                            {
+                                doubleTapTime = capi.ElapsedMilliseconds + VerticalityModSystem.ClientConfig.doubleTapSpeed;
+                            }
+                        }
+                    } else
+                    {
+                        sneakPressed = false;
+                    }
+                }
+            
             return false;
         }
 

--- a/Verticality/VerticalityModConfig.cs
+++ b/Verticality/VerticalityModConfig.cs
@@ -20,6 +20,8 @@ namespace Verticality
         
         public bool dedicatedCrawlKey = false;
         public bool combinationCrawlKeys = true;
-
+        public bool standOnJump = true;
+        public bool doubleTapSneakToCrawl = false;
+        public int doubleTapSpeed = 500;
     }
 }

--- a/Verticality/VerticalityModConfig.cs
+++ b/Verticality/VerticalityModConfig.cs
@@ -9,8 +9,12 @@ namespace Verticality
         public float climbMinHeight = 0.5f;
         public float climbGrabDistance = 0.5f;
         public float climbSpeed = 1.5f;
+        public float climbJumpHForce = 5f;
+        public float climbJumpVForce = 6f;
+
         public float chargedJumpChargeTime = 0.5f;
         public float chargedJumpAddForce = 1.9f;
+
         public float crawlSpeedReduction = -0.8f;
     }
 

--- a/Verticality/VerticalityModConfig.cs
+++ b/Verticality/VerticalityModConfig.cs
@@ -23,5 +23,6 @@ namespace Verticality
         public bool standOnJump = true;
         public bool doubleTapSneakToCrawl = false;
         public int doubleTapSpeed = 500;
+        public bool holdCrawl = false;
     }
 }

--- a/Verticality/changes.txt
+++ b/Verticality/changes.txt
@@ -1,4 +1,4 @@
-- Changed how I do versioning; please don't be alarmed by the sudden jump by 3 minor versions
+- Changed how I do versioning; please don't be alarmed by the sudden jump of 3 minor versions
 
 - Patched up some cases where you could grab through another block
 - Now possible to grab overhangs (currently somewhat limited, needs more work)
@@ -6,3 +6,5 @@
 - Added option for player to stop crawling when pressing jump (enabled by default)
 - Added option for player to start crawling by double-tapping sneak (disabled by default)
 - Added hold-crawl option (disabled by default)
+
+- Added climb-jump: jump while climbing to jump away from the surface you've grabbed

--- a/Verticality/changes.txt
+++ b/Verticality/changes.txt
@@ -5,3 +5,4 @@
 
 - Added option for player to stop crawling when pressing jump (enabled by default)
 - Added option for player to start crawling by double-tapping sneak (disabled by default)
+- Added hold-crawl option (disabled by default)

--- a/Verticality/changes.txt
+++ b/Verticality/changes.txt
@@ -1,2 +1,7 @@
-- removed game version dependency (I forgot to update it the last few updates anyway)
-- yet another attempt at fixing these crawl multiplayer issues
+- Changed how I do versioning; please don't be alarmed by the sudden jump by 3 minor versions
+
+- Patched up some cases where you could grab through another block
+- Now possible to grab overhangs (currently somewhat limited, needs more work)
+
+- Added option for player to stop crawling when pressing jump (enabled by default)
+- Added option for player to start crawling by double-tapping sneak (disabled by default)

--- a/resources/modinfo.json
+++ b/resources/modinfo.json
@@ -6,7 +6,7 @@
     "Professor Cupcake"
   ],
   "description": "Climbing! Also jumping! And crawling!",
-  "version": "0.0.12",
+  "version": "0.3.0",
   "dependencies": {
     "game": "*"
   }


### PR DESCRIPTION
- Changed how I do versioning; please don't be alarmed by the sudden jump of 3 minor versions

- Patched up some cases where you could grab through another block
- Now possible to grab overhangs (currently somewhat limited, needs more work)

- Added option for player to stop crawling when pressing jump (enabled by default)
- Added option for player to start crawling by double-tapping sneak (disabled by default)
- Added hold-crawl option (disabled by default)

- Added climb-jump: press jump while climbing to jump away from the surface you've grabbed
- Added config options to adjust the climb jump force